### PR TITLE
Improve logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,7 @@ It is recommended that you store this as a [GitHub Secret](https://docs.github.c
 ### `app_names` **_REQUIRED_**
 
 An array of Heroku app names that the branch should be deployed to.
+
+### `debug` _OPTIONAL_
+
+Prints extra logs from Heroku CLI and git commands, which should help in cases where things aren't working and the error messages don't help.

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   debug:
     description: "Prints extra logs from Heroku CLI and git commands"
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: "node16"

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: "Names of the apps on Heroku"
     required: true
   debug:
-    description: "Prints extra logs from Heroku CLI and git commands"
+    description: "Prints extra logs from Heroku CLI and git commands, use 'true' to enable"
     required: false
     default: "false"
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   app_names:
     description: "Names of the apps on Heroku"
     required: true
+  debug:
+    description: "Prints extra logs from Heroku CLI and git commands"
+    required: false
 
 runs:
   using: "node16"

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,7 @@ inputs:
   debug:
     description: "Prints extra logs from Heroku CLI and git commands"
     required: false
+    default: false
 
 runs:
   using: "node16"

--- a/dist/index.js
+++ b/dist/index.js
@@ -1546,7 +1546,7 @@ var import_core2 = __toESM(require_core());
 var addRemotes = (appNames) => {
   const addRemote = (app) => {
     try {
-      (0, import_child_process2.execSync)(`heroku git:remote --app ${app}`);
+      (0, import_child_process2.execSync)(`heroku git:remote --app ${app}`, { stdio: "ignore" });
       (0, import_child_process2.execSync)(`git remote rename heroku ${app}`);
       printSuccess("Set remote with Heroku CLI", app);
     } catch (e) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -698,12 +698,12 @@ var require_http_client = __commonJS({
           throw new Error("Client has already been disposed.");
         }
         let parsedUrl = new URL(requestUrl);
-        let info3 = this._prepareRequest(verb, parsedUrl, headers);
+        let info4 = this._prepareRequest(verb, parsedUrl, headers);
         let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1 ? this._maxRetries + 1 : 1;
         let numTries = 0;
         let response;
         while (numTries < maxTries) {
-          response = await this.requestRaw(info3, data);
+          response = await this.requestRaw(info4, data);
           if (response && response.message && response.message.statusCode === HttpCodes.Unauthorized) {
             let authenticationHandler;
             for (let i = 0; i < this.handlers.length; i++) {
@@ -713,7 +713,7 @@ var require_http_client = __commonJS({
               }
             }
             if (authenticationHandler) {
-              return authenticationHandler.handleAuthentication(this, info3, data);
+              return authenticationHandler.handleAuthentication(this, info4, data);
             } else {
               return response;
             }
@@ -736,8 +736,8 @@ var require_http_client = __commonJS({
                 }
               }
             }
-            info3 = this._prepareRequest(verb, parsedRedirectUrl, headers);
-            response = await this.requestRaw(info3, data);
+            info4 = this._prepareRequest(verb, parsedRedirectUrl, headers);
+            response = await this.requestRaw(info4, data);
             redirectsRemaining--;
           }
           if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
@@ -757,7 +757,7 @@ var require_http_client = __commonJS({
         }
         this._disposed = true;
       }
-      requestRaw(info3, data) {
+      requestRaw(info4, data) {
         return new Promise((resolve, reject) => {
           let callbackForResult = function(err, res) {
             if (err) {
@@ -765,13 +765,13 @@ var require_http_client = __commonJS({
             }
             resolve(res);
           };
-          this.requestRawWithCallback(info3, data, callbackForResult);
+          this.requestRawWithCallback(info4, data, callbackForResult);
         });
       }
-      requestRawWithCallback(info3, data, onResult) {
+      requestRawWithCallback(info4, data, onResult) {
         let socket;
         if (typeof data === "string") {
-          info3.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
+          info4.options.headers["Content-Length"] = Buffer.byteLength(data, "utf8");
         }
         let callbackCalled = false;
         let handleResult = (err, res) => {
@@ -780,7 +780,7 @@ var require_http_client = __commonJS({
             onResult(err, res);
           }
         };
-        let req = info3.httpModule.request(info3.options, (msg) => {
+        let req = info4.httpModule.request(info4.options, (msg) => {
           let res = new HttpClientResponse(msg);
           handleResult(null, res);
         });
@@ -791,7 +791,7 @@ var require_http_client = __commonJS({
           if (socket) {
             socket.end();
           }
-          handleResult(new Error("Request timeout: " + info3.options.path), null);
+          handleResult(new Error("Request timeout: " + info4.options.path), null);
         });
         req.on("error", function(err) {
           handleResult(err, null);
@@ -813,27 +813,27 @@ var require_http_client = __commonJS({
         return this._getAgent(parsedUrl);
       }
       _prepareRequest(method, requestUrl, headers) {
-        const info3 = {};
-        info3.parsedUrl = requestUrl;
-        const usingSsl = info3.parsedUrl.protocol === "https:";
-        info3.httpModule = usingSsl ? https : http;
+        const info4 = {};
+        info4.parsedUrl = requestUrl;
+        const usingSsl = info4.parsedUrl.protocol === "https:";
+        info4.httpModule = usingSsl ? https : http;
         const defaultPort = usingSsl ? 443 : 80;
-        info3.options = {};
-        info3.options.host = info3.parsedUrl.hostname;
-        info3.options.port = info3.parsedUrl.port ? parseInt(info3.parsedUrl.port) : defaultPort;
-        info3.options.path = (info3.parsedUrl.pathname || "") + (info3.parsedUrl.search || "");
-        info3.options.method = method;
-        info3.options.headers = this._mergeHeaders(headers);
+        info4.options = {};
+        info4.options.host = info4.parsedUrl.hostname;
+        info4.options.port = info4.parsedUrl.port ? parseInt(info4.parsedUrl.port) : defaultPort;
+        info4.options.path = (info4.parsedUrl.pathname || "") + (info4.parsedUrl.search || "");
+        info4.options.method = method;
+        info4.options.headers = this._mergeHeaders(headers);
         if (this.userAgent != null) {
-          info3.options.headers["user-agent"] = this.userAgent;
+          info4.options.headers["user-agent"] = this.userAgent;
         }
-        info3.options.agent = this._getAgent(info3.parsedUrl);
+        info4.options.agent = this._getAgent(info4.parsedUrl);
         if (this.handlers) {
           this.handlers.forEach((handler) => {
-            handler.prepareRequest(info3.options);
+            handler.prepareRequest(info4.options);
           });
         }
-        return info3;
+        return info4;
       }
       _mergeHeaders(headers) {
         const lowercaseKeys = (obj) => Object.keys(obj).reduce((c, k) => (c[k.toLowerCase()] = obj[k], c), {});
@@ -1449,10 +1449,10 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
       command_1.issueCommand("notice", utils_1.toCommandProperties(properties), message instanceof Error ? message.toString() : message);
     }
     exports.notice = notice;
-    function info3(message) {
+    function info4(message) {
       process.stdout.write(message + os.EOL);
     }
-    exports.info = info3;
+    exports.info = info4;
     function startGroup(name) {
       command_1.issue("group", name);
     }
@@ -1511,8 +1511,7 @@ var printInfo = (message, app) => {
   (0, import_core.info)(!!app ? formatAppMessage(message, app) : message);
 };
 var printSuccess = (message, app) => {
-  const greenMessage = `\x1B[32m${message}
-`;
+  const greenMessage = `\x1B[32m${message}`;
   (0, import_core.info)(!!app ? formatAppMessage(greenMessage, app) : greenMessage);
 };
 var printError = (message, app) => {
@@ -1537,7 +1536,7 @@ machine git.heroku.com
     login ${email}
     password ${apiKey}
 EOF`);
-  printSuccess("Created ~/.netrc");
+  printSuccess("Created ~/.netrc\n");
 };
 
 // src/git.ts
@@ -1548,15 +1547,15 @@ var addRemotes = (appNames) => {
   const addRemote = (app) => {
     try {
       (0, import_child_process2.execSync)(`heroku git:remote --app ${app}`);
-      printSuccess("Set remote with Heroku CLI", app);
       (0, import_child_process2.execSync)(`git remote rename heroku ${app}`);
-      printSuccess("Renamed remote", app);
+      printSuccess("Set remote with Heroku CLI", app);
     } catch (e) {
       printError("An error occurred whilst setting remote", app);
       e instanceof Error && (0, import_core2.setFailed)(e);
     }
   };
   appNames.forEach(addRemote);
+  (0, import_core2.info)("\n");
 };
 var processKillTriggerWords = [
   "building source",
@@ -1565,7 +1564,7 @@ var processKillTriggerWords = [
 ];
 var testForKill = (input) => {
   for (const triggerWord in processKillTriggerWords) {
-    if (input.includes(processKillTriggerWords[triggerWord])) {
+    if (input.includes(triggerWord)) {
       return triggerWord;
     }
   }
@@ -1576,7 +1575,7 @@ var handleProcessOutput = (data, app, pushed) => {
   const matchingWord = testForKill(data.toString());
   if (!!matchingWord) {
     printInfo(`Detected: "${matchingWord}`, app);
-    printInfo("Marking app as pushed", app);
+    printSuccess("Marking app as pushed", app);
     pushed(app);
   }
 };
@@ -1594,6 +1593,7 @@ var pushRemotes = async (appNames, branch) => {
   try {
     const pushedApps = await Promise.all(appNames.map(pushRemote));
     printSuccess(`Finished pushing apps: ${pushedApps.toString()}`);
+    (0, import_core2.info)("\n");
   } catch (e) {
     printError("Something went wrong pushing apps");
     e instanceof Error && (0, import_core2.setFailed)(e);
@@ -1612,17 +1612,18 @@ var main = async () => {
   if (!["main", "master"].includes(branch)) {
     (0, import_core3.setFailed)(`Branch must be 'master' or 'main' - got: ${branch}`);
   }
-  printSuccess(`Branch name is set to ${branch}`);
+  printSuccess(`Branch name is set to ${branch}
+`);
   (0, import_core3.info)("Checking all input variables are present...");
   checkInputs(inputs);
-  printSuccess("All inputs present");
+  printSuccess("All inputs present\n");
   (0, import_core3.info)("Creating .netrc file...");
   createNetrcFile(inputs.email, inputs.apiKey);
   (0, import_core3.info)("Setting remotes");
   addRemotes(inputs.appNames);
   (0, import_core3.info)("Starting push to Heroku remotes");
   await pushRemotes(inputs.appNames, branch);
-  printSuccess("Finished pushing to Heroku remotes!");
+  printSuccess("All done!");
   process.exit();
 };
 main().catch((err) => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1518,9 +1518,9 @@ var printError = (message, app) => {
   const redMessage = `\x1B[31m${message}`;
   (0, import_core.error)(!!app ? formatAppMessage(redMessage, app) : redMessage);
 };
+var formatAppMessage = (message, app) => `[\x1B[36m${app}] \x1B[0m${message}`;
 
 // src/utils.ts
-var formatAppMessage = (message, app) => `[${app}] ${message}`;
 var checkInputs = (inputs2) => {
   const missingValues = Object.entries(inputs2).reduce((missing, [inputName, inputValue]) => !!inputValue && !!inputValue.length ? missing : [...missing, inputName], []);
   if (missingValues.length) {
@@ -1555,7 +1555,7 @@ var addRemotes = (appNames) => {
     }
   };
   appNames.forEach(addRemote);
-  (0, import_core2.info)("\n");
+  (0, import_core2.info)("");
 };
 var processKillTriggerWords = [
   "building source",
@@ -1592,7 +1592,7 @@ var pushToRemotes = async (appNames, branch) => {
   try {
     const pushedApps = await Promise.all(appNames.map(pushToRemote));
     printSuccess(`Finished pushing apps: ${pushedApps.toString()}`);
-    (0, import_core2.info)("\n");
+    (0, import_core2.info)("");
   } catch (e) {
     printError("Something went wrong pushing apps");
     e instanceof Error && (0, import_core2.setFailed)(e);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1526,7 +1526,7 @@ var formatAppMessage = (message, app) => `[\x1B[36m${app}] \x1B[0m${message}`;
 
 // src/utils.ts
 var checkInputs = (inputs2) => {
-  const missingInputs = Object.entries(inputs2).reduce((missing, [inputName, inputValue]) => !!inputValue || Array.isArray(inputValue) && !!inputValue.length ? missing : [...missing, inputName], []);
+  const missingInputs = Object.entries(inputs2).reduce((missing, [inputName, inputValue]) => inputName === "debug" && typeof inputValue === "boolean" || typeof inputValue === "string" && !!inputValue || Array.isArray(inputValue) && !!inputValue.length ? missing : [...missing, inputName], []);
   if (missingInputs.length) {
     throw new Error(`Missing input variable(s): ${missingInputs.toString()}`);
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1403,7 +1403,7 @@ var require_core = __commonJS({
       return inputs2;
     }
     exports.getMultilineInput = getMultilineInput2;
-    function getBooleanInput2(name, options) {
+    function getBooleanInput(name, options) {
       const trueValue = ["true", "True", "TRUE"];
       const falseValue = ["false", "False", "FALSE"];
       const val = getInput2(name, options);
@@ -1414,7 +1414,7 @@ var require_core = __commonJS({
       throw new TypeError(`Input does not meet YAML 1.2 "Core Schema" specification: ${name}
 Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
-    exports.getBooleanInput = getBooleanInput2;
+    exports.getBooleanInput = getBooleanInput;
     function setOutput(name, value) {
       process.stdout.write(os.EOL);
       command_1.issueCommand("set-output", { name }, value);
@@ -1530,6 +1530,7 @@ var checkInputs = (inputs2) => {
   if (missingInputs.length) {
     throw new Error(`Missing input variable(s): ${missingInputs.toString()}`);
   }
+  printSuccess("All inputs present\n");
 };
 var createNetrcFile = (email, apiKey) => {
   (0, import_child_process.execSync)(`cat >~/.netrc <<EOF
@@ -1615,7 +1616,7 @@ var inputs = {
   email: (0, import_core3.getInput)("email"),
   apiKey: (0, import_core3.getInput)("api_key"),
   appNames: (0, import_core3.getMultilineInput)("app_names"),
-  debug: (0, import_core3.getBooleanInput)("debug")
+  debug: (0, import_core3.getInput)("debug").toLowerCase() === "true"
 };
 var main = async () => {
   (0, import_core3.info)("Checking branch...");
@@ -1627,7 +1628,6 @@ var main = async () => {
 `);
   (0, import_core3.info)("Checking all input variables are present...");
   checkInputs(inputs);
-  printSuccess("All inputs present\n");
   (0, import_core3.info)("Creating .netrc file...");
   createNetrcFile(inputs.email, inputs.apiKey);
   (0, import_core3.info)("Setting remotes");

--- a/dist/index.js
+++ b/dist/index.js
@@ -1578,8 +1578,8 @@ var handleProcessOutput = (data, app, pushed) => {
     pushed(app);
   }
 };
-var pushRemotes = async (appNames, branch) => {
-  const pushRemote = (app) => new Promise((pushed, failed) => {
+var pushToRemotes = async (appNames, branch) => {
+  const pushToRemote = (app) => new Promise((pushed, failed) => {
     printInfo(`Pushing ${branch} to remote`, app);
     const pushProcess = (0, import_child_process2.spawn)("git", ["push", app, branch]);
     pushProcess.stdout.on("data", (data) => handleProcessOutput(data, app, pushed));
@@ -1590,7 +1590,7 @@ var pushRemotes = async (appNames, branch) => {
     });
   });
   try {
-    const pushedApps = await Promise.all(appNames.map(pushRemote));
+    const pushedApps = await Promise.all(appNames.map(pushToRemote));
     printSuccess(`Finished pushing apps: ${pushedApps.toString()}`);
     (0, import_core2.info)("\n");
   } catch (e) {
@@ -1621,7 +1621,7 @@ var main = async () => {
   (0, import_core3.info)("Setting remotes");
   addRemotes(inputs.appNames);
   (0, import_core3.info)("Starting push to Heroku remotes");
-  await pushRemotes(inputs.appNames, branch);
+  await pushToRemotes(inputs.appNames, branch);
   printSuccess("All done!");
   process.exit();
 };

--- a/dist/index.js
+++ b/dist/index.js
@@ -1563,18 +1563,17 @@ var processKillTriggerWords = [
   "compressing source files"
 ];
 var testForKill = (input) => {
-  for (const triggerWord in processKillTriggerWords) {
-    if (input.includes(triggerWord)) {
-      return triggerWord;
+  for (const wordIndex in processKillTriggerWords) {
+    if (input.includes(processKillTriggerWords[wordIndex])) {
+      return processKillTriggerWords[wordIndex];
     }
   }
   return false;
 };
 var handleProcessOutput = (data, app, pushed) => {
-  printInfo(`${data.toString()}`, app);
   const matchingWord = testForKill(data.toString());
   if (!!matchingWord) {
-    printInfo(`Detected: "${matchingWord}`, app);
+    printInfo(`Detected: "${matchingWord}"`, app);
     printSuccess("Marking app as pushed", app);
     pushed(app);
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -12,7 +12,7 @@ import { printError, printInfo, printSuccess } from "./logging";
 export const addRemotes = (appNames: string[]) => {
   const addRemote = (app: string) => {
     try {
-      execSync(`heroku git:remote --app ${app}`);
+      execSync(`heroku git:remote --app ${app}`, { stdio: "ignore" });
       execSync(`git remote rename heroku ${app}`);
       printSuccess("Set remote with Heroku CLI", app);
     } catch (e) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -80,8 +80,8 @@ const handleProcessOutput = (
  *
  * @return promise which resolves once all remotes have finished pushing
  */
-export const pushRemotes = async (appNames: string[], branch: string) => {
-  const pushRemote = (app: string) =>
+export const pushToRemotes = async (appNames: string[], branch: string) => {
+  const pushToRemote = (app: string) =>
     new Promise<string>((pushed, failed) => {
       printInfo(`Pushing ${branch} to remote`, app);
       const pushProcess = spawn("git", ["push", app, branch]);
@@ -104,7 +104,7 @@ export const pushRemotes = async (appNames: string[], branch: string) => {
     });
 
   try {
-    const pushedApps = await Promise.all(appNames.map(pushRemote));
+    const pushedApps = await Promise.all(appNames.map(pushToRemote));
     printSuccess(`Finished pushing apps: ${pushedApps.toString()}`);
     // Leave some space after
     info("\n");

--- a/src/git.ts
+++ b/src/git.ts
@@ -23,7 +23,7 @@ export const addRemotes = (appNames: string[]) => {
 
   appNames.forEach(addRemote);
   // Leave some space after
-  info("\n");
+  info("");
 };
 
 /**
@@ -107,7 +107,7 @@ export const pushToRemotes = async (appNames: string[], branch: string) => {
     const pushedApps = await Promise.all(appNames.map(pushToRemote));
     printSuccess(`Finished pushing apps: ${pushedApps.toString()}`);
     // Leave some space after
-    info("\n");
+    info("");
   } catch (e) {
     printError("Something went wrong pushing apps");
     e instanceof Error && setFailed(e);

--- a/src/git.ts
+++ b/src/git.ts
@@ -46,9 +46,9 @@ const processKillTriggerWords = [
  * @param input string input from stdio
  */
 export const testForKill = (input: string) => {
-  for (const wordIndex in processKillTriggerWords) {
-    if (input.includes(processKillTriggerWords[wordIndex])) {
-      return processKillTriggerWords[wordIndex];
+  for (const triggerWord of processKillTriggerWords) {
+    if (input.includes(triggerWord)) {
+      return triggerWord;
     }
   }
   return false;

--- a/src/git.ts
+++ b/src/git.ts
@@ -43,25 +43,30 @@ const processKillTriggerWords = [
  * @param input string input from stdio
  */
 export const testForKill = (input: string) => {
-  for (const triggerWord in processKillTriggerWords) {
-    if (input.includes(triggerWord)) {
-      return triggerWord;
+  for (const wordIndex in processKillTriggerWords) {
+    if (input.includes(processKillTriggerWords[wordIndex])) {
+      return processKillTriggerWords[wordIndex];
     }
   }
   return false;
 };
 
+/**
+ * Handler which takes the process output and resolves if matched word is found.
+ *
+ * @param data process data
+ * @param app app name
+ * @param pushed app promise callback
+ */
 const handleProcessOutput = (
   data: Buffer,
   app: string,
   pushed: (app: string) => void
 ) => {
-  printInfo(`${data.toString()}`, app);
-
   const matchingWord = testForKill(data.toString());
 
   if (!!matchingWord) {
-    printInfo(`Detected: "${matchingWord}`, app);
+    printInfo(`Detected: "${matchingWord}"`, app);
     printSuccess("Marking app as pushed", app);
     pushed(app);
   }

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,5 @@
 import { execSync, spawn } from "child_process";
-import { setFailed } from "@actions/core";
+import { info, setFailed } from "@actions/core";
 import { printError, printInfo, printSuccess } from "./logging";
 
 /**
@@ -13,9 +13,8 @@ export const addRemotes = (appNames: string[]) => {
   const addRemote = (app: string) => {
     try {
       execSync(`heroku git:remote --app ${app}`);
-      printSuccess("Set remote with Heroku CLI", app);
       execSync(`git remote rename heroku ${app}`);
-      printSuccess("Renamed remote", app);
+      printSuccess("Set remote with Heroku CLI", app);
     } catch (e) {
       printError("An error occurred whilst setting remote", app);
       e instanceof Error && setFailed(e);
@@ -23,6 +22,8 @@ export const addRemotes = (appNames: string[]) => {
   };
 
   appNames.forEach(addRemote);
+  // Leave some space after
+  info("\n");
 };
 
 /**
@@ -43,7 +44,7 @@ const processKillTriggerWords = [
  */
 export const testForKill = (input: string) => {
   for (const triggerWord in processKillTriggerWords) {
-    if (input.includes(processKillTriggerWords[triggerWord])) {
+    if (input.includes(triggerWord)) {
       return triggerWord;
     }
   }
@@ -61,7 +62,7 @@ const handleProcessOutput = (
 
   if (!!matchingWord) {
     printInfo(`Detected: "${matchingWord}`, app);
-    printInfo("Marking app as pushed", app);
+    printSuccess("Marking app as pushed", app);
     pushed(app);
   }
 };
@@ -100,6 +101,8 @@ export const pushRemotes = async (appNames: string[], branch: string) => {
   try {
     const pushedApps = await Promise.all(appNames.map(pushRemote));
     printSuccess(`Finished pushing apps: ${pushedApps.toString()}`);
+    // Leave some space after
+    info("\n");
   } catch (e) {
     printError("Something went wrong pushing apps");
     e instanceof Error && setFailed(e);

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,11 +17,11 @@ const main = async () => {
   if (!["main", "master"].includes(branch)) {
     setFailed(`Branch must be 'master' or 'main' - got: ${branch}`);
   }
-  printSuccess(`Branch name is set to ${branch}`);
+  printSuccess(`Branch name is set to ${branch}\n`);
 
   info("Checking all input variables are present...");
   checkInputs(inputs);
-  printSuccess("All inputs present");
+  printSuccess("All inputs present\n");
 
   info("Creating .netrc file...");
   createNetrcFile(inputs.email, inputs.apiKey);
@@ -31,7 +31,7 @@ const main = async () => {
 
   info("Starting push to Heroku remotes");
   await pushRemotes(inputs.appNames, branch);
-  printSuccess("Finished pushing to Heroku remotes!");
+  printSuccess("All done!");
   process.exit();
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import { execSync } from "child_process";
-import { getInput, getMultilineInput, info, setFailed } from "@actions/core";
+import {
+  getBooleanInput,
+  getInput,
+  getMultilineInput,
+  info,
+  setFailed,
+} from "@actions/core";
 import { checkInputs, createNetrcFile } from "./utils";
 import { addRemotes, pushToRemotes } from "./git";
 import { printSuccess } from "./logging";
@@ -8,6 +14,7 @@ const inputs = {
   email: getInput("email"),
   apiKey: getInput("api_key"),
   appNames: getMultilineInput("app_names"),
+  debug: getBooleanInput("debug"),
 } as const;
 
 const main = async () => {
@@ -27,10 +34,10 @@ const main = async () => {
   createNetrcFile(inputs.email, inputs.apiKey);
 
   info("Setting remotes");
-  addRemotes(inputs.appNames);
+  addRemotes(inputs.appNames, inputs.debug);
 
   info("Starting push to Heroku remotes");
-  await pushToRemotes(inputs.appNames, branch);
+  await pushToRemotes(inputs.appNames, branch, inputs.debug);
   printSuccess("All done!");
   process.exit();
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import { getInput, getMultilineInput, info, setFailed } from "@actions/core";
 import { checkInputs, createNetrcFile } from "./utils";
 import { addRemotes, pushRemotes } from "./git";
+import { printSuccess } from "./logging";
 
 const inputs = {
   email: getInput("email"),
@@ -10,27 +11,27 @@ const inputs = {
 } as const;
 
 const main = async () => {
+  info("Checking branch...");
   const branch = execSync("git branch --show-current").toString().trim();
 
   if (!["main", "master"].includes(branch)) {
     setFailed(`Branch must be 'master' or 'main' - got: ${branch}`);
   }
+  printSuccess(`Branch name is set to ${branch}`);
 
   info("Checking all input variables are present...");
   checkInputs(inputs);
-  info("All input variables are present!");
+  printSuccess("All inputs present");
 
   info("Creating .netrc file...");
   createNetrcFile(inputs.email, inputs.apiKey);
-  info("Finished creating .netrc file!");
 
-  info("Setting remote(s)...");
+  info("Setting remotes");
   addRemotes(inputs.appNames);
-  info("Finished setting remote(s)!");
 
-  info("Pushing to Heroku remote(s)...");
+  info("Starting push to Heroku remotes");
   await pushRemotes(inputs.appNames, branch);
-  info("Finished pushing to Heroku remote(s)!");
+  printSuccess("Finished pushing to Heroku remotes!");
   process.exit();
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,5 @@
 import { execSync } from "child_process";
-import {
-  getBooleanInput,
-  getInput,
-  getMultilineInput,
-  info,
-  setFailed,
-} from "@actions/core";
+import { getInput, getMultilineInput, info, setFailed } from "@actions/core";
 import { checkInputs, createNetrcFile } from "./utils";
 import { addRemotes, pushToRemotes } from "./git";
 import { printSuccess } from "./logging";
@@ -14,7 +8,7 @@ const inputs = {
   email: getInput("email"),
   apiKey: getInput("api_key"),
   appNames: getMultilineInput("app_names"),
-  debug: getBooleanInput("debug"),
+  debug: getInput("debug").toLowerCase() === "true",
 } as const;
 
 const main = async () => {
@@ -28,7 +22,6 @@ const main = async () => {
 
   info("Checking all input variables are present...");
   checkInputs(inputs);
-  printSuccess("All inputs present\n");
 
   info("Creating .netrc file...");
   createNetrcFile(inputs.email, inputs.apiKey);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import { getInput, getMultilineInput, info, setFailed } from "@actions/core";
 import { checkInputs, createNetrcFile } from "./utils";
-import { addRemotes, pushRemotes } from "./git";
+import { addRemotes, pushToRemotes } from "./git";
 import { printSuccess } from "./logging";
 
 const inputs = {
@@ -30,7 +30,7 @@ const main = async () => {
   addRemotes(inputs.appNames);
 
   info("Starting push to Heroku remotes");
-  await pushRemotes(inputs.appNames, branch);
+  await pushToRemotes(inputs.appNames, branch);
   printSuccess("All done!");
   process.exit();
 };

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -6,7 +6,7 @@ export const printInfo = (message: string, app?: string) => {
 };
 
 export const printSuccess = (message: string, app?: string) => {
-  const greenMessage = `\u001b[32m${message}\n`;
+  const greenMessage = `\u001b[32m${message}`;
   info(!!app ? formatAppMessage(greenMessage, app) : greenMessage);
 };
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,16 @@
+import { error, info } from "@actions/core";
+import { formatAppMessage } from "./utils";
+
+export const printInfo = (message: string, app?: string) => {
+  info(!!app ? formatAppMessage(message, app) : message);
+};
+
+export const printSuccess = (message: string, app?: string) => {
+  const greenMessage = `\u001b[32m${message}\n`;
+  info(!!app ? formatAppMessage(greenMessage, app) : greenMessage);
+};
+
+export const printError = (message: string, app?: string) => {
+  const redMessage = `\u001b[31m${message}`;
+  error(!!app ? formatAppMessage(redMessage, app) : redMessage);
+};

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,14 +1,34 @@
 import { error, info } from "@actions/core";
 
+/**
+ * Prints an info message
+ *
+ * @param message log message
+ * @param app app name for log format
+ */
 export const printInfo = (message: string, app?: string) => {
   info(!!app ? formatAppMessage(message, app) : message);
 };
 
+/**
+ * Prints a green success message
+ *
+ * @param message log message
+ * @param app app name for log format
+ */
 export const printSuccess = (message: string, app?: string) => {
   const greenMessage = `\u001b[32m${message}`;
   info(!!app ? formatAppMessage(greenMessage, app) : greenMessage);
 };
 
+/**
+ * Prints a red error message
+ *
+ * Note: this doesn't actually throw an error
+ *
+ * @param message log message
+ * @param app app name for log format
+ */
 export const printError = (message: string, app?: string) => {
   const redMessage = `\u001b[31m${message}`;
   error(!!app ? formatAppMessage(redMessage, app) : redMessage);

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -41,4 +41,4 @@ export const printError = (message: string, app?: string) => {
  * @param app app name
  */
 const formatAppMessage = (message: string, app: string) =>
-  `[${app}] ${message}`;
+  `[\u001b[36m${app}] \u001b[0m${message}`;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,5 +1,4 @@
 import { error, info } from "@actions/core";
-import { formatAppMessage } from "./utils";
 
 export const printInfo = (message: string, app?: string) => {
   info(!!app ? formatAppMessage(message, app) : message);
@@ -14,3 +13,12 @@ export const printError = (message: string, app?: string) => {
   const redMessage = `\u001b[31m${message}`;
   error(!!app ? formatAppMessage(redMessage, app) : redMessage);
 };
+
+/**
+ * Formats a message with app name
+ *
+ * @param message message to format
+ * @param app app name
+ */
+const formatAppMessage = (message: string, app: string) =>
+  `[${app}] ${message}`;

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -35,6 +35,17 @@ export const printError = (message: string, app?: string) => {
 };
 
 /**
+ * Prints a yellow log message
+ *
+ * @param message log message
+ * @param app app name for log format
+ */
+export const printLog = (message: string, app?: string) => {
+  const yellowMessage = `\u001b[33m${message}`;
+  info(!!app ? formatAppMessage(yellowMessage, app) : yellowMessage);
+};
+
+/**
  * Formats a message with app name
  *
  * @param message message to format

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,8 @@ export const checkInputs = (
   if (missingInputs.length) {
     throw new Error(`Missing input variable(s): ${missingInputs.toString()}`);
   }
+
+  printSuccess("All inputs present\n");
 };
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,9 @@ export const checkInputs = (
 ) => {
   const missingInputs = Object.entries(inputs).reduce<string[]>(
     (missing, [inputName, inputValue]) =>
-      !!inputValue || (Array.isArray(inputValue) && !!inputValue.length)
+      (typeof inputValue === "string" && !!inputValue) ||
+      typeof inputValue === "boolean" ||
+      (Array.isArray(inputValue) && !!inputValue.length)
         ? missing
         : [...missing, inputName],
     []

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,15 +8,19 @@ import { printSuccess } from "./logging";
  *
  * @param inputs set of inputs from action input
  */
-export const checkInputs = (inputs: Record<string, string | string[]>) => {
-  const missingValues = Object.entries(inputs).reduce<string[]>(
+export const checkInputs = (
+  inputs: Record<string, string | string[] | boolean>
+) => {
+  const missingInputs = Object.entries(inputs).reduce<string[]>(
     (missing, [inputName, inputValue]) =>
-      !!inputValue && !!inputValue.length ? missing : [...missing, inputName],
+      !!inputValue || (Array.isArray(inputValue) && !!inputValue.length)
+        ? missing
+        : [...missing, inputName],
     []
   );
 
-  if (missingValues.length) {
-    throw new Error(`Missing input variable(s): ${missingValues.toString()}`);
+  if (missingInputs.length) {
+    throw new Error(`Missing input variable(s): ${missingInputs.toString()}`);
   }
 };
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,5 +45,5 @@ machine git.heroku.com
     password ${apiKey}
 EOF`);
 
-  printSuccess("Created ~/.netrc");
+  printSuccess("Created ~/.netrc\n");
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,22 @@
-import { info } from "@actions/core";
 import { execSync } from "child_process";
+import { printSuccess } from "./logging";
 
-export const printAppMessage = (app: string) => (message: string) =>
-  info(`[${app}] ${message}`);
+/**
+ * Formats a message with app name
+ *
+ * @param message message to format
+ * @param app app name
+ */
+export const formatAppMessage = (message: string, app: string) =>
+  `[${app}] ${message}`;
 
+/**
+ * Checks to see if all inputs are present.
+ *
+ * Throws an error containing any missing values
+ *
+ * @param inputs set of inputs from action input
+ */
 export const checkInputs = (inputs: Record<string, string | string[]>) => {
   const missingValues = Object.entries(inputs).reduce<string[]>(
     (missing, [inputName, inputValue]) =>
@@ -16,7 +29,13 @@ export const checkInputs = (inputs: Record<string, string | string[]>) => {
   }
 };
 
-export const createNetrcFile = (email: string, apiKey: string) =>
+/**
+ * Creates a .netrc file with user credentials
+ *
+ * @param email the users email
+ * @param apiKey the secret API key
+ */
+export const createNetrcFile = (email: string, apiKey: string) => {
   execSync(`cat >~/.netrc <<EOF
 machine api.heroku.com
     login ${email}
@@ -25,3 +44,6 @@ machine git.heroku.com
     login ${email}
     password ${apiKey}
 EOF`);
+
+  printSuccess("Created ~/.netrc");
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,15 +2,6 @@ import { execSync } from "child_process";
 import { printSuccess } from "./logging";
 
 /**
- * Formats a message with app name
- *
- * @param message message to format
- * @param app app name
- */
-export const formatAppMessage = (message: string, app: string) =>
-  `[${app}] ${message}`;
-
-/**
  * Checks to see if all inputs are present.
  *
  * Throws an error containing any missing values

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,8 +13,10 @@ export const checkInputs = (
 ) => {
   const missingInputs = Object.entries(inputs).reduce<string[]>(
     (missing, [inputName, inputValue]) =>
+      // debug input can be true or false
+      (inputName === "debug" && typeof inputValue === "boolean") ||
+      // other inputs will be string or string array
       (typeof inputValue === "string" && !!inputValue) ||
-      typeof inputValue === "boolean" ||
       (Array.isArray(inputValue) && !!inputValue.length)
         ? missing
         : [...missing, inputName],


### PR DESCRIPTION
## Summary

Fixes #3 

This PR adds some fancy colours to the log outputs when the action has run, and neatens up the log in general to be more readable.

I opted to **not** show Heroku output by default. This is because it's quite messy, and doesn't stop on `kill()` or `disconnect()` calls because the process we kill has spawned another process for the Heroku stuff, so we can't actually kill it easily from there.

Instead, a `debug` input option has been added. Setting `debug: "true"` will show all logs, including Heroku CLI and git outputs.

## Screenshots

<details>
<summary>Regular mode pushing to two apps</summary>
<img src="https://user-images.githubusercontent.com/8884999/165624341-0506ac66-30b3-472b-8086-f8cbd8c595bc.png"/>
</details>
<details>
<summary>With `debug` enabled</summary>
<img src="https://user-images.githubusercontent.com/8884999/165621362-8347c1f9-2eab-46f8-81e3-daf99fd9c7e4.png"/>
</details>
<details>
<summary>BONUS: debug in light mode</summary>
<img src="https://user-images.githubusercontent.com/8884999/165625043-cb60d706-a1e8-4e8b-8a45-4c180c695fe4.png"/>
</details>